### PR TITLE
Multi-classification

### DIFF
--- a/hdf5_serialization.hpp
+++ b/hdf5_serialization.hpp
@@ -258,6 +258,8 @@ namespace svm {
 
         void save (alps::hdf5::archive & ar) const {
             using input_t = typename Problem::input_container_type;
+            using label_t = typename Problem::label_type;
+            using ltraits = typename::svm::detail::label_traits<label_t>;
             using view_t = typename std::conditional<
                 std::is_same<svm::dataset, input_t>::value,
                 svm::data_view, input_t const&>::type;
@@ -266,13 +268,14 @@ namespace svm {
 
             if (full) {
                 boost::multi_array<double, 2> orig_data(boost::extents[prob_.size()][prob_.dim()]);
-                std::vector<double> labels(prob_.size());
+                boost::multi_array<double, 2> labels(boost::extents[prob_.size()][ltraits::label_dim]);
 
                 for (size_t i = 0; i < prob_.size(); ++i) {
                     auto p = prob_[i];
                     view_t xs = p.first;
+                    label_t const& l = p.second;
                     std::copy(xs.begin(), xs.end(), orig_data[i].begin());
-                    labels[i] = p.second;
+                    std::copy(ltraits::begin(l), ltraits::end(l), labels[i].begin());
                 }
 
                 ar["orig_data"] << orig_data;
@@ -287,6 +290,8 @@ namespace svm {
 
         void load (alps::hdf5::archive & ar) const {
             using input_t = typename Problem::input_container_type;
+            using label_t = typename Problem::label_type;
+            using ltraits = typename::svm::detail::label_traits<label_t>;
 
             size_t dim;
             ar["dim"] >> dim;
@@ -294,19 +299,21 @@ namespace svm {
 
             if (full) {
                 boost::multi_array<double, 2> orig_data;
-                std::vector<double> labels;
+                boost::multi_array<double, 2> labels;
                 ar["orig_data"] >> orig_data;
                 ar["labels"] >> labels;
 
-                if (orig_data.shape()[0] != labels.size())
+                if (orig_data.shape()[0] != labels.shape()[0])
                     throw std::runtime_error("inconsistent data length");
                 if (orig_data.shape()[1] != dim)
-                    throw std::runtime_error("inconsistent data length");
+                    throw std::runtime_error("inconsistent data dimension");
+                if (labels.shape()[1] != ltraits::label_dim)
+                    throw std::runtime_error("inconsistent label dimension");
 
-                for (size_t i = 0; i < labels.size(); ++i)
+                for (size_t i = 0; i < labels.shape()[0]; ++i)
                     prob.add_sample(input_t(orig_data[i].begin(),
                                             orig_data[i].end()),
-                                    labels[i]);
+                                    ltraits::from_iterator(labels[i].begin()));
             }
 
             prob_ = std::move(prob);

--- a/hdf5_serialization.hpp
+++ b/hdf5_serialization.hpp
@@ -251,6 +251,11 @@ namespace svm {
         problem_serializer (Problem & prob, bool skip_samples = false)
             : prob_(prob), full(!skip_samples) {}
 
+        void save (std::string const& filename) const {
+            alps::hdf5::archive ar(filename, "w");
+            save(ar);
+        }
+
         void save (alps::hdf5::archive & ar) const {
             using input_t = typename Problem::input_container_type;
             using view_t = typename std::conditional<
@@ -273,6 +278,11 @@ namespace svm {
                 ar["orig_data"] << orig_data;
                 ar["labels"] << labels;
             }
+        }
+
+        void load (std::string const& filename) {
+            alps::hdf5::archive ar(filename, "r");
+            load(ar);
         }
 
         void load (alps::hdf5::archive & ar) const {

--- a/kernel/linear.hpp
+++ b/kernel/linear.hpp
@@ -55,15 +55,14 @@ namespace svm {
         }
     };
 
-    template <class Kernel>
+    template <class Classifier>
     struct linear_introspector {
-        using model_t = model<Kernel>;
 
-        linear_introspector(model_t const& model) : model_(model) {}
+        linear_introspector(Classifier const& cl) : classifier(cl) {}
         
         double coefficient(size_t i) const {
             double c = 0;
-            for (auto p : model_) {
+            for (auto p : classifier) {
                 double yalpha = p.first;
                 auto const& x = p.second;
                 auto itX = x.begin();
@@ -73,8 +72,17 @@ namespace svm {
             return c;
         }
 
+        double right_hand_side() const {
+            return classifier.rho();
+        }
+
     private:
-        model_t const& model_;
+        Classifier classifier;
     };
+
+    template <class Classifier>
+    linear_introspector<Classifier> linear_introspect (Classifier const& cl) {
+        return linear_introspector<Classifier> {cl};
+    }
 
 }

--- a/kernel/linear.hpp
+++ b/kernel/linear.hpp
@@ -36,9 +36,9 @@ namespace svm {
 
     }
 
-    template <>
-    class problem<kernel::linear> : public detail::patch_through_problem {
-        using detail::patch_through_problem::patch_through_problem;
+    template <class Label>
+    class problem<kernel::linear, Label> : public detail::patch_through_problem<Label> {
+        using detail::patch_through_problem<Label>::patch_through_problem;
     };
 
     template <>

--- a/kernel/polynomial.hpp
+++ b/kernel/polynomial.hpp
@@ -43,9 +43,9 @@ namespace svm {
 
     }
 
-    template <size_t D>
-    class problem<kernel::polynomial<D>> : public detail::patch_through_problem {
-        using detail::patch_through_problem::patch_through_problem;
+    template <size_t D, class Label>
+    class problem<kernel::polynomial<D>, Label> : public detail::patch_through_problem<Label> {
+        using detail::patch_through_problem<Label>::patch_through_problem;
     };
 
     template <size_t D>

--- a/kernel/rbf.hpp
+++ b/kernel/rbf.hpp
@@ -35,9 +35,9 @@ namespace svm {
 
     }
 
-    template <>
-    class problem<kernel::rbf> : public detail::patch_through_problem {
-        using detail::patch_through_problem::patch_through_problem;
+    template <class Label>
+    class problem<kernel::rbf, Label> : public detail::patch_through_problem<Label> {
+        using detail::patch_through_problem<Label>::patch_through_problem;
     };
 
     template <>

--- a/kernel/sigmoid.hpp
+++ b/kernel/sigmoid.hpp
@@ -35,9 +35,9 @@ namespace svm {
 
     }
 
-    template <>
-    class problem<kernel::sigmoid> : public detail::patch_through_problem {
-        using detail::patch_through_problem::patch_through_problem;
+    template <class Label>
+    class problem<kernel::sigmoid, Label> : public detail::patch_through_problem<Label> {
+        using detail::patch_through_problem<Label>::patch_through_problem;
     };
 
     template <>

--- a/label.hpp
+++ b/label.hpp
@@ -26,8 +26,9 @@
     static const char * NAMES[(LABELCOUNT)];                            \
     static double FLOAT_REPRS[(LABELCOUNT)];                            \
     struct label {                                                      \
-        static const size_t nr_classes = (LABELCOUNT);                  \
+        static const size_t nr_labels = (LABELCOUNT);                   \
         static const size_t label_dim = 1;                              \
+        label () : val(FLOAT_REPRS[0] + 0.5) {}                         \
         label (short val) : val(val) {}                                 \
         label (short val, const char * c_str) : val(val) {              \
             NAMES[val] = c_str;                                         \
@@ -35,11 +36,11 @@
         }                                                               \
         template <class Iterator>                                       \
         label (Iterator begin) : val (*begin + 0.5) {                   \
-            if (val < 0 || val >= nr_classes)                           \
+            if (val < 0 || val >= nr_labels)                            \
                 throw std::runtime_error("invalid label");              \
         }                                                               \
         label (double x) : val (x + 0.5) {                              \
-            if (x < 0 || x >= nr_classes)                               \
+            if (x < 0 || x >= nr_labels)                                \
                 throw std::runtime_error("invalid label");              \
         }                                                               \
         operator double() const { return val; }                         \

--- a/label.hpp
+++ b/label.hpp
@@ -23,8 +23,8 @@
 
 #define SVM_LABEL_BEGIN(LABELNAME, LABELCOUNT)                          \
     namespace LABELNAME {                                               \
-    const char * NAMES[(LABELCOUNT)];                                   \
-    double FLOAT_REPRS[(LABELCOUNT)];                                   \
+    static const char * NAMES[(LABELCOUNT)];                            \
+    static double FLOAT_REPRS[(LABELCOUNT)];                            \
     struct label {                                                      \
         static const size_t number_classes = (LABELCOUNT);              \
         static const size_t label_dim = 1;                              \
@@ -54,9 +54,9 @@
     private:                                                            \
     const short val;                                                    \
     };                                                                  \
-    short i = 0;
+    static short i = 0;
 
-#define SVM_LABEL_ADD(OPTIONNAME)                   \
-    const label OPTIONNAME { i++, #OPTIONNAME };
+#define SVM_LABEL_ADD(OPTIONNAME)                       \
+    static const label OPTIONNAME { i++, #OPTIONNAME };
 
 #define SVM_LABEL_END() }

--- a/label.hpp
+++ b/label.hpp
@@ -1,6 +1,6 @@
 /*   Support Vector Machine Library Wrappers
  *   Copyright (C) 2018  Jonas Greitemann
- *  
+ *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
  *   the Free Software Foundation, either version 3 of the License, or
@@ -22,19 +22,29 @@
 #include <stdexcept>
 
 #define SVM_LABEL_BEGIN(LABELNAME, LABELCOUNT)                          \
-namespace LABELNAME {                                                   \
-    const char * NAMES[3];                                              \
+    namespace LABELNAME {                                               \
+    const char * NAMES[(LABELCOUNT)];                                   \
+    double FLOAT_REPRS[(LABELCOUNT)];                                   \
     struct label {                                                      \
         static const size_t number_classes = (LABELCOUNT);              \
-        label (short val) : val (val) {}                                \
-        label (short val, const char * c_str) : val (val) {             \
+        static const size_t label_dim = 1;                              \
+        label (short val) : val(val) {}                                 \
+        label (short val, const char * c_str) : val(val) {              \
             NAMES[val] = c_str;                                         \
+            FLOAT_REPRS[val] = double(val);                             \
+        }                                                               \
+        template <class Iterator>                                       \
+        label (Iterator begin) : val (*begin + 0.5) {                   \
+            if (val < 0 || val >= number_classes)                       \
+                throw std::runtime_error("invalid label");              \
         }                                                               \
         label (double x) : val (x + 0.5) {                              \
             if (x < 0 || x >= number_classes)                           \
                 throw std::runtime_error("invalid label");              \
         }                                                               \
         operator double() const { return val; }                         \
+        double const * begin() const { return &FLOAT_REPRS[val]; }      \
+        double const * end() const { return &FLOAT_REPRS[val] + 1; }    \
         friend bool operator== (label lhs, label rhs) {                 \
             return lhs.val == rhs.val;                                  \
         }                                                               \
@@ -42,7 +52,7 @@ namespace LABELNAME {                                                   \
             os << NAMES[l.val];                                         \
         }                                                               \
     private:                                                            \
-        const short val;                                                \
+    const short val;                                                    \
     };                                                                  \
     short i = 0;
 

--- a/label.hpp
+++ b/label.hpp
@@ -26,7 +26,7 @@
     static const char * NAMES[(LABELCOUNT)];                            \
     static double FLOAT_REPRS[(LABELCOUNT)];                            \
     struct label {                                                      \
-        static const size_t number_classes = (LABELCOUNT);              \
+        static const size_t nr_classes = (LABELCOUNT);                  \
         static const size_t label_dim = 1;                              \
         label (short val) : val(val) {}                                 \
         label (short val, const char * c_str) : val(val) {              \
@@ -35,11 +35,11 @@
         }                                                               \
         template <class Iterator>                                       \
         label (Iterator begin) : val (*begin + 0.5) {                   \
-            if (val < 0 || val >= number_classes)                       \
+            if (val < 0 || val >= nr_classes)                           \
                 throw std::runtime_error("invalid label");              \
         }                                                               \
         label (double x) : val (x + 0.5) {                              \
-            if (x < 0 || x >= number_classes)                           \
+            if (x < 0 || x >= nr_classes)                               \
                 throw std::runtime_error("invalid label");              \
         }                                                               \
         operator double() const { return val; }                         \

--- a/label.hpp
+++ b/label.hpp
@@ -49,7 +49,7 @@
             return lhs.val == rhs.val;                                  \
         }                                                               \
         friend std::ostream & operator<< (std::ostream & os, label l) { \
-            os << NAMES[l.val];                                         \
+            return os << NAMES[l.val];                                  \
         }                                                               \
     private:                                                            \
     const short val;                                                    \

--- a/label.hpp
+++ b/label.hpp
@@ -20,6 +20,7 @@
 
 #include <iostream>
 #include <stdexcept>
+#include <type_traits>
 
 #define SVM_LABEL_BEGIN(LABELNAME, LABELCOUNT)                          \
     namespace LABELNAME {                                               \
@@ -29,12 +30,13 @@
         static const size_t nr_labels = (LABELCOUNT);                   \
         static const size_t label_dim = 1;                              \
         label () : val(FLOAT_REPRS[0] + 0.5) {}                         \
-        label (short val) : val(val) {}                                 \
-        label (short val, const char * c_str) : val(val) {              \
+        label (int val) : val(val) {}                                   \
+        label (int val, const char * c_str) : val(val) {                \
             NAMES[val] = c_str;                                         \
             FLOAT_REPRS[val] = double(val);                             \
         }                                                               \
-        template <class Iterator>                                       \
+        template <class Iterator,                                       \
+                  typename Tag = typename std::iterator_traits<Iterator>::value_type> \
         label (Iterator begin) : val (*begin + 0.5) {                   \
             if (val < 0 || val >= nr_labels)                            \
                 throw std::runtime_error("invalid label");              \
@@ -53,7 +55,7 @@
             return os << NAMES[l.val];                                  \
         }                                                               \
     private:                                                            \
-    const short val;                                                    \
+        short val;                                                      \
     };                                                                  \
     static short i = 0;
 

--- a/label.hpp
+++ b/label.hpp
@@ -1,0 +1,52 @@
+/*   Support Vector Machine Library Wrappers
+ *   Copyright (C) 2018  Jonas Greitemann
+ *  
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program, see the file entitled "LICENCE" in the
+ *   repository's root directory, or see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <iostream>
+#include <stdexcept>
+
+#define SVM_LABEL_BEGIN(LABELNAME, LABELCOUNT)                          \
+namespace LABELNAME {                                                   \
+    const char * NAMES[3];                                              \
+    struct label {                                                      \
+        static const size_t number_classes = (LABELCOUNT);              \
+        label (short val) : val (val) {}                                \
+        label (short val, const char * c_str) : val (val) {             \
+            NAMES[val] = c_str;                                         \
+        }                                                               \
+        label (double x) : val (x + 0.5) {                              \
+            if (x < 0 || x >= number_classes)                           \
+                throw std::runtime_error("invalid label");              \
+        }                                                               \
+        operator double() const { return val; }                         \
+        friend bool operator== (label lhs, label rhs) {                 \
+            return lhs.val == rhs.val;                                  \
+        }                                                               \
+        friend std::ostream & operator<< (std::ostream & os, label l) { \
+            os << NAMES[l.val];                                         \
+        }                                                               \
+    private:                                                            \
+        const short val;                                                \
+    };                                                                  \
+    short i = 0;
+
+#define SVM_LABEL_ADD(OPTIONNAME)                   \
+    const label OPTIONNAME { i++, #OPTIONNAME };
+
+#define SVM_LABEL_END() }

--- a/model.hpp
+++ b/model.hpp
@@ -314,14 +314,18 @@ namespace svm {
             return std::make_pair(label, dec);
         }
 
+        template <typename..., size_t NL = nr_labels,
+                  typename = typename std::enable_if_t<NL == 2>>
         nSV_type nSV () const {
-            if (nr_labels == 2) {
-                return {m->nSV[0], m->nSV[1]};
-            } else {
-                nSV_type n;
-                std::copy(m->nSV, m->nSV + nr_labels, n.begin());
-                return n;
-            }
+            return {m->nSV[0], m->nSV[1]};
+        }
+
+        template <typename..., size_t NL = nr_labels,
+                  typename = typename std::enable_if_t<(NL > 2)>, bool dummy = false>
+        nSV_type nSV () const {
+            nSV_type n;
+            std::copy(m->nSV, m->nSV + nr_labels, n.begin());
+            return n;
         }
 
         size_t dim () const {

--- a/model.hpp
+++ b/model.hpp
@@ -213,7 +213,7 @@ namespace svm {
                                             std::pair<size_t, size_t>,
                                             std::array<size_t, nr_labels>>;
         using label_arr_t = std::array<label_type, nr_labels>;
-        using classifier_arr_t = std::array<classifier_type, nr_classifiers>;
+        using classifier_arr_t = std::vector<classifier_type>;
 
         model () : prob(0), m(nullptr) {}
 
@@ -273,9 +273,10 @@ namespace svm {
             auto it = ret.begin();
             for (size_t k1 = 0; k1 < nr_labels - 1; ++k1) {
                 for (size_t k2 = k1 + 1; k2 < nr_labels; ++k2, ++it) {
-                    *it = classifier_type(*this, k1, k2);
+                    ret.emplace_back(*this, k1, k2);
                 }
             }
+            return ret;
         }
 
         classifier_type classifier (Label l1, Label l2) const {

--- a/model.hpp
+++ b/model.hpp
@@ -37,12 +37,15 @@ namespace svm {
     template <class Kernel, class Label = double>
     class model {
     public:
+        typedef Kernel kernel_type;
         typedef problem<Kernel, Label> problem_t;
         typedef parameters<Kernel> parameters_t;
         typedef typename problem_t::input_container_type input_container_type;
         typedef Label label_type;
 
         struct classifier_type {
+
+            using kernel_type = model::kernel_type;
 
             struct const_iterator {
                 using support_vec_type = std::conditional_t<problem_t::is_precomputed,

--- a/model.hpp
+++ b/model.hpp
@@ -262,6 +262,12 @@ namespace svm {
             return classifier_type {*this, k1, k2};
         }
 
+        template <typename..., size_t NC = nr_classifiers,
+                  typename = std::enable_if_t<NC == 1>>
+        classifier_type classifier () const {
+            return classifier_type {*this, 0, 1};
+        }
+
         template <typename Problem = problem_t,
                   typename = std::enable_if_t<!Problem::is_precomputed>>
         std::pair<Label, decision_type> operator() (input_container_type const& xj) {
@@ -278,18 +284,6 @@ namespace svm {
             decision_type dec;
             Label label(svm_predict_values(m, kernelized.ptr(), reinterpret_cast<double*>(&dec)));
             return std::make_pair(label, dec);
-        }
-
-        template <typename..., size_t NC = nr_classifiers,
-                  typename = std::enable_if_t<NC == 1>>
-        typename classifier_type::const_iterator begin () const {
-            return classifier_type {*this, 0, 1}.begin();
-        }
-
-        template <typename..., size_t NC = nr_classifiers,
-                  typename = std::enable_if_t<NC == 1>>
-        typename classifier_type::const_iterator end () const {
-            return classifier_type {*this, 0, 1}.end();
         }
 
         double rho () const {

--- a/model.hpp
+++ b/model.hpp
@@ -40,6 +40,8 @@ namespace svm {
         typedef typename problem_t::input_container_type input_container_type;
         typedef Label label_type;
 
+        static const size_t nr_classes = detail::label_traits<Label>::nr_classes;
+
         class const_iterator {
         public:
             const_iterator & operator++ () {

--- a/model.hpp
+++ b/model.hpp
@@ -40,7 +40,140 @@ namespace svm {
         typedef parameters<Kernel> parameters_t;
         typedef typename problem_t::input_container_type input_container_type;
         typedef Label label_type;
-        typedef std::pair<Label, Label> classifier_type;
+
+        struct classifier_type {
+
+            struct const_iterator {
+                using support_vec_type = std::conditional_t<problem_t::is_precomputed,
+                                                            input_container_type,
+                                                            data_view>;
+                using support_vec_ref = std::conditional_t<problem_t::is_precomputed,
+                                                           input_container_type const&,
+                                                           data_view>;
+                using value_type = std::pair<double, support_vec_type>;
+                using reference = std::pair<double const&, support_vec_ref> const;
+                using pointer = std::pair<double, support_vec_ref> const *;
+                using iterator_category = std::bidirectional_iterator_tag;
+
+                const_iterator & operator++ () {
+                    ++yalpha;
+                    ++sv;
+                    if (yalpha == yalpha_1_end) {
+                        yalpha = yalpha_2;
+                        sv = sv_2;
+                    }
+                    return *this;
+                }
+                const_iterator operator++ (int) {
+                    const_iterator old(*this);
+                    ++(*this);
+                    return old;
+                }
+                const_iterator & operator-- () {
+                    if (yalpha == yalpha_2) {
+                        yalpha = yalpha_1_end;
+                        sv = sv_1_end;
+                    }
+                    --yalpha;
+                    --sv;
+                    return *this;
+                }
+                const_iterator operator-- (int) {
+                    const_iterator old(*this);
+                    --(*this);
+                    return old;
+                }
+                double coef () const {
+                    return *yalpha;
+                }
+
+                template <typename Problem = problem_t,
+                        typename = std::enable_if_t<!Problem::is_precomputed>>
+                data_view support_vec () const {
+                    return data_view(*sv);
+                }
+
+                template <typename Problem = problem_t,
+                        typename = std::enable_if_t<Problem::is_precomputed>,
+                        bool dummy = false>
+                input_container_type const& support_vec () const {
+                    data_view permutation_index(*sv, 0);
+                    return prob[permutation_index.front()-1].first;
+                }
+
+                auto operator* () const {
+                    return std::make_pair(coef(), support_vec());
+                }
+
+                friend bool operator== (const_iterator lhs, const_iterator rhs) {
+                    return lhs.yalpha == rhs.yalpha && lhs.sv == rhs.sv;
+                }
+                friend bool operator!= (const_iterator lhs, const_iterator rhs) {
+                    return lhs.yalpha != rhs.yalpha || lhs.sv != rhs.sv;
+                }
+
+                friend struct classifier_type;
+
+            private:
+                const_iterator (double * yalpha_1, struct svm_node ** sv_1,
+                                double * yalpha_1_end, struct svm_node ** sv_1_end,
+                                double * yalpha_2, struct svm_node ** sv_2,
+                                problem_t const& prob)
+                    : yalpha(yalpha_1), sv(sv_1),
+                      yalpha_1_end(yalpha_1_end), sv_1_end(sv_1_end),
+                      yalpha_2(yalpha_2), sv_2(sv_2), prob(prob) {}
+                double * yalpha, * yalpha_1_end, * yalpha_2;
+                struct svm_node ** sv, **sv_1_end, **sv_2;
+                problem_t const& prob;
+            };
+
+            using iterator = const_iterator;
+
+            classifier_type (model const& parent, size_t k1, size_t k2)
+                : parent(parent), k1(k1), k2(k2) {
+                if (k1 > k2) {
+                    std::swap(k1, k2);
+                    std::swap(this->k1, this->k2);
+                }
+                size_t sum = 0;
+                for (size_t k = 0; k < model::nr_labels; ++k) {
+                    if (k == k1)
+                        k1_offset = sum;
+                    if (k == k2)
+                        k2_offset = sum;
+                    sum += parent.m->nSV[k];
+                }
+            }
+
+            const_iterator begin () const {
+                return const_iterator {
+                    parent.m->sv_coef[k2-1] + k1_offset,
+                    parent.m->SV + k1_offset,
+                    parent.m->sv_coef[k2-1] + k1_offset + parent.m->nSV[k1],
+                    parent.m->SV + k1_offset + parent.m->nSV[k1],
+                    parent.m->sv_coef[k1] + k2_offset,
+                    parent.m->SV + k2_offset,
+                    parent.prob
+                };
+            }
+
+            const_iterator end () const {
+                return const_iterator {
+                    parent.m->sv_coef[k1] + k2_offset + parent.m->nSV[k2],
+                    parent.m->SV + k2_offset + parent.m->nSV[k2],
+                    parent.m->sv_coef[k2-1] + k1_offset + parent.m->nSV[k1],
+                    parent.m->SV + k1_offset + parent.m->nSV[k1],
+                    parent.m->sv_coef[k1] + k2_offset,
+                    parent.m->SV + k2_offset,
+                    parent.prob
+                };
+            }
+
+        private:
+            size_t k1, k2;
+            size_t k1_offset, k2_offset;
+            model const& parent;
+        };
 
         static const size_t nr_labels = detail::label_traits<Label>::nr_labels;
         static const size_t nr_classifiers = nr_labels * (nr_labels - 1) / 2;
@@ -49,68 +182,11 @@ namespace svm {
                                                  double,
                                                  std::array<double, nr_classifiers>>;
 
+        using nSV_type = std::conditional_t<nr_labels == 2,
+                                            std::pair<size_t, size_t>,
+                                            std::array<size_t, nr_labels>>;
         using label_arr_t = std::array<label_type, nr_labels>;
         using classifier_arr_t = std::array<classifier_type, nr_classifiers>;
-
-        class const_iterator {
-        public:
-            const_iterator & operator++ () {
-                ++yalpha;
-                ++sv;
-                return *this;
-            }
-            const_iterator operator++ (int) {
-                const_iterator old(*this);
-                ++(*this);
-                return old;
-            }
-            const_iterator & operator-- () {
-                --yalpha;
-                --sv;
-                return *this;
-            }
-            const_iterator operator-- (int) {
-                const_iterator old(*this);
-                --(*this);
-                return old;
-            }
-            double coef () const {
-                return *yalpha;
-            }
-
-            template <typename Problem = problem_t,
-                      typename = std::enable_if_t<!Problem::is_precomputed>>
-            data_view support_vec () const {
-                return data_view(*sv);
-            }
-
-            template <typename Problem = problem_t,
-                      typename = std::enable_if_t<Problem::is_precomputed>,
-                      bool dummy = false>
-            input_container_type const& support_vec () const {
-                data_view permutation_index(*sv, 0);
-                return prob[permutation_index.front()-1].first;
-            }
-
-            auto operator* () const {
-                return std::make_pair(coef(), support_vec());
-            }
-
-            friend bool operator== (const_iterator lhs, const_iterator rhs) {
-                return lhs.yalpha == rhs.yalpha && lhs.sv == rhs.sv;
-            }
-            friend bool operator!= (const_iterator lhs, const_iterator rhs) {
-                return lhs.yalpha != rhs.yalpha || lhs.sv != rhs.sv;
-            }
-
-            friend model;
-        private:
-            const_iterator (double * yalpha, struct svm_node ** sv, problem_t const& prob)
-                : yalpha(yalpha), sv(sv), prob(prob) {}
-            double * yalpha;
-            struct svm_node ** sv;
-            problem_t const& prob;
-        };
 
         model () : prob(0), m(nullptr) {}
 
@@ -164,12 +240,26 @@ namespace svm {
         }
 
         classifier_arr_t classifiers () const {
-            auto ls = labels();
             classifier_arr_t ret;
+            auto ls = labels();
             auto it = ret.begin();
-            for (auto l1 = ls.begin(); l1 != ls.end(); ++l1)
-                for (auto l2 = l1; l2 != ls.end(); ++l2, ++it)
-                    *it = classifier_type(*l1, *l2);
+            for (size_t k1 = 0; k1 < nr_labels - 1; ++k1) {
+                for (size_t k2 = k1 + 1; k2 < nr_labels; ++k2, ++it) {
+                    *it = classifier_type(*this, k1, k2);
+                }
+            }
+        }
+
+        classifier_type classifier (Label l1, Label l2) const {
+            auto ls = labels();
+            size_t k1, k2;
+            for (size_t k = 0; k < nr_labels; ++k) {
+                if (l1 == ls[k])
+                    k1 = k;
+                if (l2 == ls[k])
+                    k2 = k;
+            }
+            return classifier_type {*this, k1, k2};
         }
 
         template <typename Problem = problem_t,
@@ -190,19 +280,30 @@ namespace svm {
             return std::make_pair(label, dec);
         }
 
-        const_iterator begin () const {
-            return const_iterator(m->sv_coef[0], m->SV, prob);
+        template <typename..., size_t NC = nr_classifiers,
+                  typename = std::enable_if_t<NC == 1>>
+        typename classifier_type::const_iterator begin () const {
+            return classifier_type {*this, 0, 1}.begin();
         }
-        const_iterator end () const {
-            return const_iterator(m->sv_coef[0] + m->l, m->SV + m->l, prob);
+
+        template <typename..., size_t NC = nr_classifiers,
+                  typename = std::enable_if_t<NC == 1>>
+        typename classifier_type::const_iterator end () const {
+            return classifier_type {*this, 0, 1}.end();
         }
 
         double rho () const {
             return m->rho[0];
         }
 
-        std::pair<size_t, size_t> nSV () const {
-            return {m->nSV[0], m->nSV[1]};
+        nSV_type nSV () const {
+            if (nr_labels == 2) {
+                return {m->nSV[0], m->nSV[1]};
+            } else {
+                nSV_type n;
+                std::copy(m->nSV, m->nSV + nr_labels, n.begin());
+                return n;
+            }
         }
 
         size_t dim () const {

--- a/model.hpp
+++ b/model.hpp
@@ -32,12 +32,13 @@
 
 namespace svm {
 
-    template <class Kernel>
+    template <class Kernel, class Label = double>
     class model {
     public:
-        typedef problem<Kernel> problem_t;
+        typedef problem<Kernel, Label> problem_t;
         typedef parameters<Kernel> parameters_t;
         typedef typename problem_t::input_container_type input_container_type;
+        typedef Label label_type;
 
         class const_iterator {
         public:
@@ -140,17 +141,17 @@ namespace svm {
         }
 
         template <typename Problem = problem_t, typename = typename std::enable_if<!Problem::is_precomputed>::type>
-        std::pair<double, double> operator() (input_container_type const& xj) {
+        std::pair<Label, double> operator() (input_container_type const& xj) {
             double dec;
-            double label =  svm_predict_values(m, xj.ptr(), &dec);
+            Label label(svm_predict_values(m, xj.ptr(), &dec));
             return std::make_pair(label, dec);
         }
 
         template <typename Problem = problem_t, typename = typename std::enable_if<Problem::is_precomputed>::type, bool dummy = false>
-        std::pair<double, double> operator() (input_container_type const& xj) {
+        std::pair<Label, double> operator() (input_container_type const& xj) {
             dataset kernelized = prob.kernelize(xj);
             double dec;
-            double label = svm_predict_values(m, kernelized.ptr(), &dec);
+            Label label(svm_predict_values(m, kernelized.ptr(), &dec));
             return std::make_pair(label, dec);
         }
 

--- a/model.hpp
+++ b/model.hpp
@@ -235,7 +235,7 @@ namespace svm {
 
         label_arr_t labels () const {
             label_arr_t ret;
-            std::copy(m->label, m->label + nr_labels, ret);
+            std::copy(m->label, m->label + nr_labels, ret.begin());
             return ret;
         }
 

--- a/problem.hpp
+++ b/problem.hpp
@@ -167,7 +167,7 @@ namespace svm {
 
             template <class OtherProblem, typename UnaryFunction>
             precompute_kernel_problem(OtherProblem && other, UnaryFunction map)
-                : basic_problem<dataset, Label>(std::move(other), map), kernel(std::move(other.kernel)) {}
+                : basic_problem<Container, Label>(std::move(other), map), kernel(std::move(other.kernel)) {}
 
             template <typename = typename std::enable_if<std::is_default_constructible<Kernel>::value>::type>
             precompute_kernel_problem (size_t dim)
@@ -204,6 +204,9 @@ namespace svm {
 
             template <class OtherContainer, class OtherLabel>
             friend class basic_problem;
+
+            template <class OtherKernel, class OtherContainer, class OtherLabel>
+            friend class precompute_kernel_problem;
         private:
             using basic_problem<Container, Label>::orig_data;
             using basic_problem<Container, Label>::labels;

--- a/problem.hpp
+++ b/problem.hpp
@@ -128,10 +128,13 @@ namespace svm {
                 ptrs.clear();
                 for (dataset & ds : orig_data)
                     ptrs.push_back(ds.ptr());
+                raw_labels.clear();
+                for (Label const& l : labels)
+                    raw_labels.push_back(l);
                 struct svm_problem p;
                 p.x = ptrs.data();
-                p.y = labels.data();
-                p.l = labels.size();
+                p.y = raw_labels.data();
+                p.l = raw_labels.size();
                 return p;
             }
 
@@ -141,6 +144,7 @@ namespace svm {
             using basic_problem<dataset, Label>::orig_data;
             using basic_problem<dataset, Label>::labels;
             std::vector<struct svm_node *> ptrs;
+            std::vector<double> raw_labels;
         };
 
         template <class Kernel, class Container, class Label>

--- a/problem.hpp
+++ b/problem.hpp
@@ -33,6 +33,13 @@ namespace svm {
 
     namespace detail {
 
+        template <class Label>
+        struct is_convertible_label
+            : std::integral_constant<bool,
+                                     bool(std::is_convertible<Label, double>::value)
+                                     && bool(std::is_convertible<double, Label>::value)
+                                     > {};
+
         template <class Container, class Label>
         class basic_problem {
         public:
@@ -124,6 +131,8 @@ namespace svm {
             patch_through_problem(OtherProblem && other, UnaryFunction map)
                 : basic_problem<dataset, Label>(std::move(other), map) {}
 
+            template <typename ..., typename L = Label,
+                      typename = typename std::enable_if<is_convertible_label<L>::value>::type>
             struct svm_problem generate() {
                 ptrs.clear();
                 for (dataset & ds : orig_data)
@@ -167,6 +176,8 @@ namespace svm {
             precompute_kernel_problem (const Kernel & k, size_t dim)
                 : basic_problem<Container, Label>(dim), kernel(k) {}
 
+            template <typename ..., class L = Label,
+                      typename = typename std::enable_if<is_convertible_label<L>::value>::type>
             struct svm_problem generate() {
                 kernel_data.clear();
                 ptrs.clear();

--- a/problem.hpp
+++ b/problem.hpp
@@ -43,6 +43,7 @@ namespace svm {
         template <class Label>
         struct label_traits {
             static const size_t label_dim = Label::label_dim;
+            static const size_t nr_classes = Label::nr_classes;
             static auto begin (Label const& l) {
                 return l.begin();
             }
@@ -58,6 +59,7 @@ namespace svm {
         template <>
         struct label_traits<double> {
             static const size_t label_dim = 1;
+            static const size_t nr_classes = 2;
             static double const * begin (double const& l) { return &l; }
             static double const* end (double const& l) { return &l + 1; }
             template <class Iterator>

--- a/problem.hpp
+++ b/problem.hpp
@@ -40,6 +40,32 @@ namespace svm {
                                      && bool(std::is_convertible<double, Label>::value)
                                      > {};
 
+        template <class Label>
+        struct label_traits {
+            static const size_t label_dim = Label::label_dim;
+            static auto begin (Label const& l) {
+                return l.begin();
+            }
+            static auto end (Label const& l) {
+                return l.end();
+            }
+            template <class Iterator>
+            static Label from_iterator (Iterator begin) {
+                return Label(begin);
+            }
+        };
+
+        template <>
+        struct label_traits<double> {
+            static const size_t label_dim = 1;
+            static double const * begin (double const& l) { return &l; }
+            static double const* end (double const& l) { return &l + 1; }
+            template <class Iterator>
+            static double from_iterator (Iterator begin) {
+                return *begin;
+            }
+        };
+
         template <class Container, class Label>
         class basic_problem {
         public:

--- a/problem.hpp
+++ b/problem.hpp
@@ -100,6 +100,9 @@ namespace svm {
             void map_labels (UnaryFunction const& map) {
                 std::transform(labels.begin(), labels.end(), labels.begin(), map);
             }
+
+            template <class OtherContainer, class OtherLabel>
+            friend class basic_problem;
         protected:
             std::vector<Container> orig_data;
             std::vector<Label> labels;
@@ -131,6 +134,9 @@ namespace svm {
                 p.l = labels.size();
                 return p;
             }
+
+            template <class OtherContainer, class OtherLabel>
+            friend class basic_problem;
         private:
             using basic_problem<dataset, Label>::orig_data;
             using basic_problem<dataset, Label>::labels;
@@ -180,6 +186,9 @@ namespace svm {
                 }
                 return dataset(v, 0, false);
             }
+
+            template <class OtherContainer, class OtherLabel>
+            friend class basic_problem;
         private:
             using basic_problem<Container, Label>::orig_data;
             using basic_problem<Container, Label>::labels;

--- a/problem.hpp
+++ b/problem.hpp
@@ -43,7 +43,7 @@ namespace svm {
         template <class Label>
         struct label_traits {
             static const size_t label_dim = Label::label_dim;
-            static const size_t nr_classes = Label::nr_classes;
+            static const size_t nr_labels = Label::nr_labels;
             static auto begin (Label const& l) {
                 return l.begin();
             }
@@ -59,7 +59,7 @@ namespace svm {
         template <>
         struct label_traits<double> {
             static const size_t label_dim = 1;
-            static const size_t nr_classes = 2;
+            static const size_t nr_labels = 2;
             static double const * begin (double const& l) { return &l; }
             static double const* end (double const& l) { return &l + 1; }
             template <class Iterator>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(combinatorics combinatorics.cpp)
 add_test(combinatorics combinatorics)
 
 add_executable(problem problem.cpp)
+target_link_libraries(problem svm)
 add_test(problem problem)
 
 add_executable(hyperplane-builtin hyperplane_builtin.cpp)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -43,6 +43,10 @@ add_executable(poly-introspect poly_introspect.cpp)
 target_link_libraries(poly-introspect svm)
 add_test(poly-introspect poly-introspect)
 
+add_executable(multi-introspect multi_introspect.cpp)
+target_link_libraries(multi-introspect svm)
+add_test(multi-introspect multi-introspect)
+
 add_executable(ascii-serialization ascii_serialization.cpp)
 target_link_libraries(ascii-serialization svm)
 add_test(ascii-serialization ascii-serialization)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,6 +5,9 @@ include_directories(doctest)
 add_executable(combinatorics combinatorics.cpp)
 add_test(combinatorics combinatorics)
 
+add_executable(problem problem.cpp)
+add_test(problem problem)
+
 add_executable(hyperplane-builtin hyperplane_builtin.cpp)
 target_link_libraries(hyperplane-builtin svm)
 add_test(hyperplane-builtin hyperplane-builtin)

--- a/test/ascii_serialization.cpp
+++ b/test/ascii_serialization.cpp
@@ -22,10 +22,18 @@
 #include "kernel/linear_precomputed.hpp"
 
 
-TEST_CASE("serializer-ascii-builtin") {
-    serializer_test<svm::kernel::linear, svm::ascii_tag>(4, 1000, 0.99, "ascii-builtin");
+TEST_CASE("model-serializer-ascii-builtin") {
+    model_serializer_test<svm::kernel::linear, svm::ascii_tag>(4, 1000, 0.99, "ascii-builtin");
 }
 
-TEST_CASE("serializer-ascii-precomputed") {
-    serializer_test<svm::kernel::linear_precomputed, svm::ascii_tag>(4, 1000, 0.99, "ascii-precomputed");
+TEST_CASE("model-serializer-ascii-precomputed") {
+    model_serializer_test<svm::kernel::linear_precomputed, svm::ascii_tag>(4, 1000, 0.99, "ascii-precomputed");
+}
+
+TEST_CASE("problem-serializer-ascii-builtin") {
+    problem_serializer_test<svm::kernel::linear, svm::ascii_tag>(4, 1000, "ascii-builtin");
+}
+
+TEST_CASE("problem-serializer-ascii-precomputed") {
+    problem_serializer_test<svm::kernel::linear_precomputed, svm::ascii_tag>(4, 1000, "ascii-precomputed");
 }

--- a/test/ascii_serialization.cpp
+++ b/test/ascii_serialization.cpp
@@ -23,17 +23,17 @@
 
 
 TEST_CASE("model-serializer-ascii-builtin") {
-    model_serializer_test<svm::kernel::linear, svm::ascii_tag>(4, 1000, 0.99, "ascii-builtin");
+    model_serializer_test<svm::kernel::linear, svm::ascii_tag>(4, 1000, 0.99, "ascii-builtin-model");
 }
 
 TEST_CASE("model-serializer-ascii-precomputed") {
-    model_serializer_test<svm::kernel::linear_precomputed, svm::ascii_tag>(4, 1000, 0.99, "ascii-precomputed");
+    model_serializer_test<svm::kernel::linear_precomputed, svm::ascii_tag>(4, 1000, 0.99, "ascii-precomputed-model");
 }
 
 TEST_CASE("problem-serializer-ascii-builtin") {
-    problem_serializer_test<svm::kernel::linear, svm::ascii_tag>(4, 1000, "ascii-builtin");
+    problem_serializer_test<svm::kernel::linear, svm::ascii_tag>(4, 1000, "ascii-builtin-problem.txt");
 }
 
 TEST_CASE("problem-serializer-ascii-precomputed") {
-    problem_serializer_test<svm::kernel::linear_precomputed, svm::ascii_tag>(4, 1000, "ascii-precomputed");
+    problem_serializer_test<svm::kernel::linear_precomputed, svm::ascii_tag>(4, 1000, "ascii-precomputed-problem.txt");
 }

--- a/test/hyperplane_coeffs.cpp
+++ b/test/hyperplane_coeffs.cpp
@@ -41,7 +41,7 @@ void hyperplane_coeffs_test (size_t N, size_t M, double eps) {
         fill_problem<svm::problem<Kernel>>(M, rng, trial_model),
         params);
     using input_t = typename svm::model<Kernel>::input_container_type;
-    svm::linear_introspector<Kernel> introspector(empirical_model);
+    auto introspector = linear_introspect(empirical_model.classifier());
 
     std::vector<double> empirical_C(N);
     for (size_t i = 0; i < N; ++i)
@@ -66,7 +66,7 @@ void hyperplane_coeffs_test (size_t N, size_t M, double eps) {
             d_calc += *itC * x;
             ++itC;
         }
-        d_calc -= empirical_model.rho();
+        d_calc -= introspector.right_hand_side();
         std::tie(std::ignore, d_pred) = empirical_model(input_t(std::move(xs)));
         CHECK(d_calc == doctest::Approx(d_pred));
     }

--- a/test/model_test.hpp
+++ b/test/model_test.hpp
@@ -78,8 +78,8 @@ void model_test (size_t M, double threshold, TrialModel const& trial_model, RNG_
     using model_t = svm::model<Kernel>;
     svm::parameters<Kernel> params(nu);
 
-    size_t nr_classes = model_t::nr_classes;
-    CHECK(nr_classes == 2);
+    size_t nr_labels = model_t::nr_labels;
+    CHECK(nr_labels == 2);
 
     model_t empirical_model(
         fill_problem<svm::problem<Kernel>>(M, rng, trial_model),

--- a/test/model_test.hpp
+++ b/test/model_test.hpp
@@ -75,8 +75,13 @@ double test_model (size_t M, RNG & rng,
 
 template <class Kernel, class TrialModel, class RNG_t = std::mt19937>
 void model_test (size_t M, double threshold, TrialModel const& trial_model, RNG_t rng = RNG_t(42), double nu = 0.1) {
+    using model_t = svm::model<Kernel>;
     svm::parameters<Kernel> params(nu);
-    svm::model<Kernel> empirical_model(
+
+    size_t nr_classes = model_t::nr_classes;
+    CHECK(nr_classes == 2);
+
+    model_t empirical_model(
         fill_problem<svm::problem<Kernel>>(M, rng, trial_model),
         params);
 

--- a/test/multi_introspect.cpp
+++ b/test/multi_introspect.cpp
@@ -1,0 +1,207 @@
+/*   Support Vector Machine Library Wrappers
+ *   Copyright (C) 2018  Jonas Greitemann
+ *  
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program, see the file entitled "LICENCE" in the
+ *   repository's root directory, or see <http://www.gnu.org/licenses/>.
+ */
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+
+#include "doctest.h"
+#include "svm-wrapper.hpp"
+#include "label.hpp"
+#include "test_problems_equal.hpp"
+
+#include <complex>
+#include <cmath>
+#include <iostream>
+#include <random>
+#include <type_traits>
+#include <vector>
+
+
+using svm::detail::basic_problem;
+
+SVM_LABEL_BEGIN(binary_class, 2)
+SVM_LABEL_ADD(RED)
+SVM_LABEL_ADD(BLUE)
+SVM_LABEL_END()
+
+SVM_LABEL_BEGIN(ternary_class, 3)
+SVM_LABEL_ADD(RED)
+SVM_LABEL_ADD(GREEN)
+SVM_LABEL_ADD(BLUE)
+SVM_LABEL_END()
+
+TEST_CASE("ternary-introspection") {
+    using label_t = ternary_class::label;
+    using cmplx = std::complex<double>;
+    using kernel_t = svm::kernel::linear;
+    using problem_t = svm::problem<kernel_t, label_t>;
+    using C = typename problem_t::input_container_type;
+
+    const size_t M = 10000;
+    const double eps = 0.01;
+
+    std::mt19937 rng(42);
+    std::uniform_real_distribution<double> uniform(-1, 1);
+
+    problem_t prob(2);
+    for (size_t i = 0; i < M; ++i) {
+        cmplx c {uniform(rng), uniform(rng)};
+        label_t l = [c] {
+            double angle = std::arg(c);
+            if (angle < -1) return ternary_class::RED;
+            if (angle <  1) return ternary_class::GREEN;
+            return ternary_class::BLUE;
+        } ();
+        prob.add_sample(C {c.real(), c.imag()}, l);
+    }
+
+    using model_t = svm::model<kernel_t, label_t>;
+    size_t nr_labels = model_t::nr_labels;
+    size_t nr_classifiers = model_t::nr_classifiers;
+
+    model_t model(std::move(prob), svm::parameters<kernel_t> {0.01});
+
+    using introspector_t = svm::linear_introspector<model_t::classifier_type>;
+    auto check_slope = [&] (label_t l1, label_t l2, double s) {
+        auto classifier = model.classifier(l1, l2);
+        introspector_t introspector(classifier);
+        double slope = -introspector.coefficient(0) / introspector.coefficient(1);
+        double intercept = classifier.rho() / introspector.coefficient(1);
+        std::cout << l1 << '/' << l2 << ": slope " << slope
+                  << ", y-intercept: " << intercept << std::endl;
+        CHECK(slope == doctest::Approx(s).epsilon(eps));
+        CHECK(intercept == doctest::Approx(0.).epsilon(eps));
+    };
+
+    check_slope(ternary_class::RED, ternary_class::GREEN, tan(-1));
+    check_slope(ternary_class::BLUE, ternary_class::GREEN, tan(1));
+    check_slope(ternary_class::RED, ternary_class::BLUE, 0.);
+}
+
+TEST_CASE("classifier-consistency") {
+    using label2_t = binary_class::label;
+    using label3_t = ternary_class::label;
+    using cmplx = std::complex<double>;
+    using kernel_t = svm::kernel::linear;
+    using problem2_t = svm::problem<kernel_t, label2_t>;
+    using problem3_t = svm::problem<kernel_t, label3_t>;
+    using C = typename problem2_t::input_container_type;
+
+    const size_t M = 1000;
+
+    std::mt19937 rng(42);
+    std::uniform_real_distribution<double> uniform(-1, 1);
+
+    problem2_t prob2(2);
+    problem3_t prob3(2);
+    for (size_t i = 0; i < M; ++i) {
+        cmplx c {uniform(rng), uniform(rng)};
+        double angle = std::arg(c);
+        if (angle < -1) {
+            prob2.add_sample(C {c.real(), c.imag()},  binary_class::RED);
+            prob3.add_sample(C {c.real(), c.imag()}, ternary_class::RED);
+        } else if (angle <  1) {
+            prob3.add_sample(C {c.real(), c.imag()}, ternary_class::GREEN);
+        } else {
+            prob2.add_sample(C {c.real(), c.imag()},  binary_class::BLUE);
+            prob3.add_sample(C {c.real(), c.imag()}, ternary_class::BLUE);
+        }
+    }
+
+    using model2_t = svm::model<kernel_t, label2_t>;
+    using model3_t = svm::model<kernel_t, label3_t>;
+
+    model2_t model2(std::move(prob2), svm::parameters<kernel_t> {});
+    model3_t model3(std::move(prob3), svm::parameters<kernel_t> {});
+
+    auto cl2 = model2.classifier();
+    auto cl3 = model3.classifier(ternary_class::RED, ternary_class::BLUE);
+
+    CHECK(cl2.rho() == doctest::Approx(cl3.rho()));
+
+    auto it2 = cl2.begin();
+    auto it3 = cl3.begin();
+    double ya2, ya3;
+    svm::data_view sv2, sv3;
+    while (it2 != cl2.end()) {
+        std::tie(ya2, sv2) = *it2;
+        std::tie(ya3, sv3) = *it3;
+        if (ya3 == doctest::Approx(0.)) {
+            ++it3;
+            continue;
+        }
+        CHECK(ya2 == doctest::Approx(ya3));
+        CHECK(sv2.front() == sv3.front());
+        ++it2, ++it3;
+    }
+    while (it3 != cl3.end()) {
+        std::tie(ya3, std::ignore) = *it3;
+        CHECK(ya3 == doctest::Approx(0.));
+        ++it3;
+    }
+}
+
+TEST_CASE("introspector-consistency") {
+    using label2_t = binary_class::label;
+    using label3_t = ternary_class::label;
+    using cmplx = std::complex<double>;
+    using kernel_t = svm::kernel::linear;
+    using problem2_t = svm::problem<kernel_t, label2_t>;
+    using problem3_t = svm::problem<kernel_t, label3_t>;
+    using C = typename problem2_t::input_container_type;
+
+    const size_t N = 250;
+    const size_t M = 1000;
+
+    std::mt19937 rng(42);
+    std::uniform_real_distribution<double> uniform(-1, 1);
+
+    problem2_t prob2(N);
+    problem3_t prob3(N);
+    for (size_t i = 0; i < M; ++i) {
+        std::vector<double> v(N);
+        for (auto & e : v)
+            e = uniform(rng);
+        cmplx c {v[0], v[1]};
+        double angle = std::arg(c);
+        if (angle < -1) {
+            prob2.add_sample(C {v},  binary_class::RED);
+            prob3.add_sample(C {v}, ternary_class::RED);
+        } else if (angle <  1) {
+            prob3.add_sample(C {v}, ternary_class::GREEN);
+        } else {
+            prob2.add_sample(C {v},  binary_class::BLUE);
+            prob3.add_sample(C {v}, ternary_class::BLUE);
+        }
+    }
+
+    using model2_t = svm::model<kernel_t, label2_t>;
+    using model3_t = svm::model<kernel_t, label3_t>;
+
+    model2_t model2(std::move(prob2), svm::parameters<kernel_t> {});
+    model3_t model3(std::move(prob3), svm::parameters<kernel_t> {});
+
+    auto cl2 = model2.classifier();
+    auto cl3 = model3.classifier(ternary_class::RED, ternary_class::BLUE);
+
+    auto introspector2 = svm::linear_introspect(cl2);
+    auto introspector3 = svm::linear_introspect(cl3);
+
+    for (size_t i = 0; i < N; ++i)
+        CHECK(introspector2.coefficient(i)
+              == doctest::Approx(introspector3.coefficient(i)));
+}

--- a/test/poly_introspect.cpp
+++ b/test/poly_introspect.cpp
@@ -54,7 +54,7 @@ static const model_t model = [] {
 static const array_t ya = [] {
     array_t ya;
     auto it = ya.begin();
-    for (auto p : model) {
+    for (auto p : model.classifier()) {
         std::tie(*(it), std::ignore) = p;
         std::cout << *it << std::endl;
         ++it;
@@ -63,12 +63,12 @@ static const array_t ya = [] {
 } ();
 
 TEST_CASE("polynomial-introspect-scalar") {
-    svm::tensor_introspector<kernel_t, 0> introspector(model);
+    auto introspector = svm::tensor_introspect<0>(model.classifier());
     CHECK(introspector.tensor() == doctest::Approx(0.25));
 }
 
 TEST_CASE("polynomial-introspect-vector") {
-    svm::tensor_introspector<kernel_t, 1> introspector(model);
+    auto introspector = svm::tensor_introspect<1>(model.classifier());
     array_t u = {0, 0, 0, 0};
     auto itX = xs.begin();
     auto itYA = ya.begin();
@@ -83,7 +83,7 @@ TEST_CASE("polynomial-introspect-vector") {
 }
 
 TEST_CASE("polynomial-introspect-matrix") {
-    svm::tensor_introspector<kernel_t, 2> introspector(model);
+    auto introspector = svm::tensor_introspect<2>(model.classifier());
     std::array<array_t, 4> u {
         array_t {0, 0, 0, 0},
         array_t {0, 0, 0, 0},

--- a/test/problem.cpp
+++ b/test/problem.cpp
@@ -1,0 +1,109 @@
+/*   Support Vector Machine Library Wrappers
+ *   Copyright (C) 2018  Jonas Greitemann
+ *  
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program, see the file entitled "LICENCE" in the
+ *   repository's root directory, or see <http://www.gnu.org/licenses/>.
+ */
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+
+#include "doctest.h"
+#include "problem.hpp"
+
+#include <vector>
+
+
+using svm::detail::basic_problem;
+
+template <class Container, class Label>
+void test_problems_equal(basic_problem<Container, Label> const& lhs,
+                         basic_problem<Container, Label> const& rhs)
+{
+    CHECK(lhs.dim() == rhs.dim());
+    CHECK(lhs.size() == rhs.size());
+    for (size_t i = 0; i < lhs.size(); ++i) {
+        Container xl, xr;
+        Label yl, yr;
+        std::tie(xl, yl) = lhs[i];
+        std::tie(xr, yr) = lhs[i];
+        CHECK(xl.size() == lhs.dim());
+        CHECK(xr.size() == rhs.dim());
+        auto it_l = xl.begin();
+        auto it_r = xr.begin();
+        for (; it_l < xl.end(); ++it_l, ++it_r)
+            CHECK(*it_l == *it_r);
+        CHECK(yl == yr);
+    }
+}
+
+TEST_CASE("problem-append") {
+    using C = std::vector<int>;
+    using prob = basic_problem<C, int>;
+
+    prob a(3), b(3), c(3);
+
+    int i = 0;
+    for (i = 0; i < 21; ++i) {
+        a.add_sample(C {3*i, 3*i+1, 3*i+2}, i);
+        b.add_sample(C {3*i, 3*i+1, 3*i+2}, i);
+    }
+    for (; i < 42; ++i) {
+        a.add_sample(C {3*i, 3*i+1, 3*i+2}, i);
+        c.add_sample(C {3*i, 3*i+1, 3*i+2}, i);
+    }
+
+    b.append_problem(std::move(c));
+
+    test_problems_equal(a, b);
+    CHECK(c.size() == 0);
+}
+
+TEST_CASE("problem-map-construct") {
+    using C = std::vector<int>;
+    using prob = basic_problem<C, int>;
+
+    prob a(3), c(3);
+
+    for (int i = 0; i < 42; ++i) {
+        a.add_sample(C {3*i, 3*i+1, 3*i+2}, i % 3);
+        c.add_sample(C {3*i, 3*i+1, 3*i+2}, i);
+    }
+
+    prob b(std::move(c), [] (int i) { return i; });
+
+    test_problems_equal(a, b);
+    CHECK(c.size() == 0);
+}
+
+TEST_CASE("problem-map-append") {
+    using C = std::vector<int>;
+    using prob = basic_problem<C, int>;
+
+    prob a(3), b(3), c(3);
+
+    int i = 0;
+    for (i = 0; i < 21; ++i) {
+        a.add_sample(C {3*i, 3*i+1, 3*i+2}, i % 3);
+        b.add_sample(C {3*i, 3*i+1, 3*i+2}, i % 3);
+    }
+    for (; i < 42; ++i) {
+        a.add_sample(C {3*i, 3*i+1, 3*i+2}, i % 3);
+        c.add_sample(C {3*i, 3*i+1, 3*i+2}, i);
+    }
+
+    b.append_problem(std::move(c), [] (int i) { return i; });
+
+    test_problems_equal(a, b);
+    CHECK(c.size() == 0);
+}

--- a/test/problem.cpp
+++ b/test/problem.cpp
@@ -123,9 +123,9 @@ TEST_CASE("problem-map-binary-classification") {
     svm::problem<kernel_t, binary_class::label> mapped_problem(std::move(prob), classifier);
 
     using model_t = svm::model<kernel_t, binary_class::label>;
-    size_t nr_classes = model_t::nr_classes;
+    size_t nr_labels = model_t::nr_labels;
     size_t nr_classifiers = model_t::nr_classifiers;
-    CHECK(nr_classes == 2);
+    CHECK(nr_labels == 2);
     CHECK(nr_classifiers == 1);
     static_assert(std::is_same<typename model_t::decision_type, double>::value,
                   "wrong decision type for binary classification");
@@ -176,9 +176,9 @@ TEST_CASE("problem-map-ternary-classification") {
     svm::problem<kernel_t, ternary_class::label> mapped_problem(std::move(prob), classifier);
 
     using model_t = svm::model<kernel_t, ternary_class::label>;
-    size_t nr_classes = model_t::nr_classes;
+    size_t nr_labels = model_t::nr_labels;
     size_t nr_classifiers = model_t::nr_classifiers;
-    CHECK(nr_classes == 3);
+    CHECK(nr_labels == 3);
     CHECK(nr_classifiers == 3);
     static_assert(std::is_same<typename model_t::decision_type, std::array<double,3>>::value,
                   "wrong decision type for binary classification");

--- a/test/problem.cpp
+++ b/test/problem.cpp
@@ -181,7 +181,7 @@ TEST_CASE("problem-map-ternary-classification") {
     CHECK(nr_labels == 3);
     CHECK(nr_classifiers == 3);
     static_assert(std::is_same<typename model_t::decision_type, std::array<double,3>>::value,
-                  "wrong decision type for binary classification");
+                  "wrong decision type for ternary classification");
 
     model_t model(std::move(mapped_problem), svm::parameters<kernel_t> {});
     double succ = 0.;

--- a/test/problem.cpp
+++ b/test/problem.cpp
@@ -122,6 +122,8 @@ TEST_CASE("problem-map-binary-classification") {
     svm::problem<kernel_t, binary_class::label> mapped_problem(std::move(prob), classifier);
 
     using model_t = svm::model<kernel_t, binary_class::label>;
+    size_t nr_classes = model_t::nr_classes;
+    CHECK(nr_classes == 2);
     model_t model(std::move(mapped_problem), svm::parameters<kernel_t> {});
     double succ = 0.;
     double dec;
@@ -170,6 +172,9 @@ TEST_CASE("problem-map-ternary-classification") {
     svm::problem<kernel_t, ternary_class::label> mapped_problem(std::move(prob), classifier);
 
     using model_t = svm::model<kernel_t, ternary_class::label>;
+    size_t nr_classes = model_t::nr_classes;
+    CHECK(nr_classes == 3);
+
     model_t model(std::move(mapped_problem), svm::parameters<kernel_t> {});
     double succ = 0.;
     double dec;

--- a/test/problem.cpp
+++ b/test/problem.cpp
@@ -64,7 +64,7 @@ TEST_CASE("problem-map-construct") {
         c.add_sample(C {3*i, 3*i+1, 3*i+2}, i);
     }
 
-    prob b(std::move(c), [] (int i) { return i; });
+    prob b(std::move(c), [] (int i) { return i % 3; });
 
     test_problems_equal(a, b);
     CHECK(c.size() == 0);
@@ -86,7 +86,7 @@ TEST_CASE("problem-map-append") {
         c.add_sample(C {3*i, 3*i+1, 3*i+2}, i);
     }
 
-    b.append_problem(std::move(c), [] (int i) { return i; });
+    b.append_problem(std::move(c), [] (int i) { return i % 3; });
 
     test_problems_equal(a, b);
     CHECK(c.size() == 0);

--- a/test/problem.cpp
+++ b/test/problem.cpp
@@ -21,36 +21,15 @@
 #include "doctest.h"
 #include "svm-wrapper.hpp"
 #include "label.hpp"
+#include "test_problems_equal.hpp"
 
 #include <complex>
 #include <iostream>
 #include <random>
 #include <vector>
-#include <tuple>
 
 
 using svm::detail::basic_problem;
-
-template <class Container, class Label>
-void test_problems_equal(basic_problem<Container, Label> const& lhs,
-                         basic_problem<Container, Label> const& rhs)
-{
-    CHECK(lhs.dim() == rhs.dim());
-    CHECK(lhs.size() == rhs.size());
-    for (size_t i = 0; i < lhs.size(); ++i) {
-        Container xl, xr;
-        Label yl, yr;
-        std::tie(xl, yl) = lhs[i];
-        std::tie(xr, yr) = lhs[i];
-        CHECK(xl.size() == lhs.dim());
-        CHECK(xr.size() == rhs.dim());
-        auto it_l = xl.begin();
-        auto it_r = xr.begin();
-        for (; it_l < xl.end(); ++it_l, ++it_r)
-            CHECK(*it_l == *it_r);
-        CHECK(yl == yr);
-    }
-}
 
 TEST_CASE("problem-append") {
     using C = std::vector<int>;

--- a/test/serialization_test.hpp
+++ b/test/serialization_test.hpp
@@ -22,6 +22,7 @@
 #include "svm-wrapper.hpp"
 #include "hyperplane_model.hpp"
 #include "model_test.hpp"
+#include "test_problems_equal.hpp"
 
 #include <iostream>
 #include <random>
@@ -30,7 +31,7 @@
 
 
 template <class Kernel, class Tag>
-void serializer_test (size_t N, size_t M, double threshold, std::string const& name) {
+void model_serializer_test (size_t N, size_t M, double threshold, std::string const& name) {
     std::mt19937 rng(42);
 
     hyperplane_model trial_model(N, rng);
@@ -52,4 +53,39 @@ void serializer_test (size_t N, size_t M, double threshold, std::string const& n
 
     success_rate = test_model(M, rng, empirical_model, restored_model);
     CHECK(success_rate == doctest::Approx(1.));
+}
+
+struct custom_label {
+    static const size_t label_dim = 2;
+    custom_label(double x, double y) { xs[0] = x; xs[1] = y; }
+    template <class Iterator>
+    custom_label(Iterator begin) { xs[0] = *begin; xs[1] = *(begin+1); }
+    double const * begin() const { return xs; }
+    double const * end() const { return xs + 2; }
+    friend bool operator== (custom_label lhs, custom_label rhs) {
+        return lhs.xs[0] == rhs.xs[0] && lhs.xs[1] == rhs.xs[1];
+    }
+private:
+    double xs[2];
+};
+
+template <class Kernel, class Tag>
+void problem_serializer_test (size_t N, size_t M, std::string const& name) {
+    using mapped_problem_t = svm::problem<Kernel, custom_label>;
+    std::mt19937 rng(42);
+
+    hyperplane_model trial_model(N, rng);
+    auto orig_prob = fill_problem<svm::problem<Kernel>>(M, rng, trial_model);
+
+    auto label_map = [] (double l) -> custom_label { return { l, (l+2)*(l+2) }; };
+    auto mapped_prob = mapped_problem_t(std::move(orig_prob), label_map);
+
+    svm::problem_serializer<Tag, mapped_problem_t> saver(mapped_prob);
+    saver.save(name);
+
+    mapped_problem_t restored_prob(0);
+    svm::problem_serializer<Tag, mapped_problem_t> loader(restored_prob);
+    loader.load(name);
+
+    test_problems_equal(mapped_prob, restored_prob);
 }

--- a/test/serialization_test.hpp
+++ b/test/serialization_test.hpp
@@ -63,7 +63,8 @@ struct custom_label {
     double const * begin() const { return xs; }
     double const * end() const { return xs + 2; }
     friend bool operator== (custom_label lhs, custom_label rhs) {
-        return lhs.xs[0] == rhs.xs[0] && lhs.xs[1] == rhs.xs[1];
+        return lhs.xs[0] == doctest::Approx(rhs.xs[0])
+            && lhs.xs[1] == doctest::Approx(rhs.xs[1]);
     }
 private:
     double xs[2];

--- a/test/test_problems_equal.hpp
+++ b/test/test_problems_equal.hpp
@@ -36,7 +36,7 @@ void test_problems_equal(basic_problem<Container, Label> const& lhs,
         auto it_l = xl.begin();
         auto it_r = xr.begin();
         for (size_t j = 0; j < lhs.dim(); ++j, ++it_l, ++it_r)
-            CHECK(*it_l == *it_r);
+            CHECK(*it_l == doctest::Approx(*it_r));
         CHECK(it_l == xl.end());
         CHECK(it_r == xr.end());
         CHECK(yl == yr);

--- a/test/test_problems_equal.hpp
+++ b/test/test_problems_equal.hpp
@@ -16,25 +16,29 @@
  *   repository's root directory, or see <http://www.gnu.org/licenses/>.
  */
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#pragma once
 
-#include "serialization_test.hpp"
-#include "kernel/linear_precomputed.hpp"
-#include "hdf5_serialization.hpp"
+#include "doctest.h"
+#include "svm-wrapper.hpp"
 
 
-TEST_CASE("model-serializer-hdf5-builtin") {
-    model_serializer_test<svm::kernel::linear, svm::hdf5_tag>(4, 1000, 0.99, "hdf5-builtin-model.h5");
-}
+using svm::detail::basic_problem;
 
-TEST_CASE("model-serializer-hdf5-precomputed") {
-    model_serializer_test<svm::kernel::linear_precomputed, svm::hdf5_tag>(4, 1000, 0.99, "hdf5-precomputed-model.h5");
-}
-
-TEST_CASE("problem-serializer-hdf5-builtin") {
-    problem_serializer_test<svm::kernel::linear, svm::hdf5_tag>(4, 1000, "hdf5-builtin-problem.h5");
-}
-
-TEST_CASE("problem-serializer-hdf5-precomputed") {
-    problem_serializer_test<svm::kernel::linear_precomputed, svm::hdf5_tag>(4, 1000, "hdf5-precomputed-problem.h5");
+template <class Container, class Label>
+void test_problems_equal(basic_problem<Container, Label> const& lhs,
+                         basic_problem<Container, Label> const& rhs)
+{
+    CHECK(lhs.dim() == rhs.dim());
+    CHECK(lhs.size() == rhs.size());
+    for (size_t i = 0; i < lhs.size(); ++i) {
+        Container const& xl = lhs[i].first, xr = rhs[i].first;
+        Label yl = lhs[i].second, yr = rhs[i].second;
+        auto it_l = xl.begin();
+        auto it_r = xr.begin();
+        for (size_t j = 0; j < lhs.dim(); ++j, ++it_l, ++it_r)
+            CHECK(*it_l == *it_r);
+        CHECK(it_l == xl.end());
+        CHECK(it_r == xr.end());
+        CHECK(yl == yr);
+    }
 }


### PR DESCRIPTION
This branch generalizes the wrapper to handle classification problems with multiple classes. A generalized concept of labels is introduced along with the set of macros SVM_LABEL_* to generate expressive labels. Problems gain the ability to map their labels (useful for pre-classify training data after sampling). The API of the wrapper remains mostly backward-compatible, with the exception of introspectors. Models are no longer directly iterable (over support vectors) but this ability has been moved into the `model::classifier_type` which represents a single decision functions. Classifiers are obtained from models, by specifying two labels in the `model::classifier` member function. (Those arguments may be omitted in a biclassification problem.)

For users, the only relevant API change for biclassification problems concerns the way introspectors are created. Rather than writing

    svm::linear_introspector<Kernel> introspector(model);

this now becomes

    auto introspector = linear_introspect(model.classifier());

where `linear_introspect` is a non-member function that can infer the template parameter (which is now the `Classifier`. Further, the `rho` member function is now a member of the classifier, not the model.